### PR TITLE
Centralize color variables

### DIFF
--- a/src/components/BlogCard/BlogCard.css
+++ b/src/components/BlogCard/BlogCard.css
@@ -19,7 +19,7 @@
   position: absolute;
   top: 1rem;
   left: 1rem;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   font-size: 0.875rem;
   font-weight: 500;
@@ -34,7 +34,7 @@
 .blog-card-title {
   font-size: 1.25rem;
   font-weight: bold;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 0.75rem;
 }
 
@@ -44,16 +44,16 @@
 }
 
 .blog-card-title a:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .blog-card-excerpt {
-  color: #6c757d;
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
 }
 
 .blog-card-read-more {
-  color: #fd1c79;
+  color: var(--color-primary);
   font-weight: 500;
   text-decoration: none;
 }

--- a/src/components/DesignerSelector/DesignerSelector.css
+++ b/src/components/DesignerSelector/DesignerSelector.css
@@ -7,7 +7,7 @@
 .designer-heading {
   font-size: 1.2rem;
   font-weight: 600;
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-bottom: 0.5rem;
 }
 
@@ -18,7 +18,7 @@
 }
 
 .designer-card {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   border: 2px solid transparent;
   border-radius: 12px;
   padding: 1.25rem 1rem 1rem 1rem;
@@ -33,7 +33,7 @@
 }
 
 .designer-card:hover {
-  border-color: #fd1c79;
+  border-color: var(--color-primary);
   transform: translateY(-2px) scale(1.025);
   background: #f753a6;
 }

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -18,7 +18,7 @@
 .logo {
   font-size: 1.5rem;
   font-weight: bold;
-  color: #fd1c79;
+  color: var(--color-primary);
   text-decoration: none;
 }
 
@@ -40,7 +40,7 @@
 }
 
 .nav-link {
-  color: #2c3e50;
+  color: var(--color-text-dark);
   display: flex;
   align-items: center;
   transition: color 0.3s;
@@ -50,7 +50,7 @@
 }
 
 .nav-link:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .icon-chevron {
@@ -81,7 +81,7 @@
 
 .dropdown-item:hover {
   background: #f3f4f6;
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .show {
@@ -101,13 +101,13 @@
 }
 
 .book-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   cursor: pointer;
 }
 
 .book-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 /* Mobile styles */
@@ -135,8 +135,8 @@
 }
 
 .mobile-nav-link:hover {
-  background: #f9fafb;
-  color: #fd1c79;
+  background: var(--color-bg-light);
+  color: var(--color-primary);
 }
 
 .mobile-dropdown {
@@ -152,8 +152,8 @@
 }
 
 .mobile-dropdown-item:hover {
-  background: #f9fafb;
-  color: #fd1c79;
+  background: var(--color-bg-light);
+  color: var(--color-primary);
 }
 
 .mobile-book-button {

--- a/src/components/OurServiceCard/OurServiceCard.css
+++ b/src/components/OurServiceCard/OurServiceCard.css
@@ -61,7 +61,7 @@
 .our-card-btn {
   margin-top: auto;
   width: 100%;
-  background: #fd1c79 !important;
+  background: var(--color-primary) !important;
   color: #fff !important;
   border-radius: 5px !important;
   font-weight: 500 !important;
@@ -72,6 +72,6 @@
   cursor: pointer;
 }
 .our-card-btn:hover {
-  background: #e01968 !important;
+  background: var(--color-primary-hover) !important;
   color: #fff !important;
 }

--- a/src/components/ServiceCard/ServiceCard.css
+++ b/src/components/ServiceCard/ServiceCard.css
@@ -25,11 +25,11 @@
   font-size: 1.25rem;
   font-weight: bold;
   margin-bottom: 0.5rem;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .service-description {
-  color: #6c757d;
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
 }
 

--- a/src/components/ServiceSelector/ServiceSelector.css
+++ b/src/components/ServiceSelector/ServiceSelector.css
@@ -7,7 +7,7 @@
 .service-selector-heading {
   font-size: 1.2rem;
   font-weight: 600;
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-bottom: 0.25rem;
 }
 
@@ -24,7 +24,7 @@
 }
 
 .service-selector-card {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   border: 2px solid transparent;
   border-radius: 10px;
   padding: 1rem;
@@ -33,12 +33,12 @@
 }
 
 .service-selector-card:hover {
-  border-color: #fd1c79;
+  border-color: var(--color-primary);
   transform: scale(1.02);
 }
 
 .service-selector-card.selected {
-  border-color: #fd1c79;
+  border-color: var(--color-primary);
   background-color: #262838;
 }
 
@@ -70,6 +70,6 @@
 }
 
 .service-selector-card.selected {
-  border: 2px solid #fd1c79;
+  border: 2px solid var(--color-primary);
   background-color: #1d1e2a;
 }

--- a/src/components/StepProgressBar/StepProgressBar.tsx
+++ b/src/components/StepProgressBar/StepProgressBar.tsx
@@ -28,19 +28,19 @@ const StepProgressBar: React.FC<StepProgressBarProps> = ({ steps, currentStep, o
               style={{
                 cursor: isClickable ? 'pointer' : 'default',
                 backgroundColor: isActive
-                  ? '#fd1c79'
+                  ? 'var(--color-primary)'
                   : isCompleted
                   ? '#e0e0e0'
                   : '#f3f3f3',
                 color: isActive
                   ? 'white'
                   : isCompleted
-                  ? '#fd1c79'
+                  ? 'var(--color-primary)'
                   : '#bbb',
                 border: isActive
-                  ? '2px solid #fd1c79'
+                  ? '2px solid var(--color-primary)'
                   : isCompleted
-                  ? '2px solid #fd1c79'
+                  ? '2px solid var(--color-primary)'
                   : '2px solid #eee',
                 boxShadow: isActive ? '0 0 0 2px #fff' : 'none',
                 transition: 'background 0.2s,color 0.2s,border 0.2s',
@@ -51,7 +51,7 @@ const StepProgressBar: React.FC<StepProgressBarProps> = ({ steps, currentStep, o
             <div
               className="step-label"
               style={{
-                color: isActive ? '#fd1c79' : isCompleted ? '#888' : '#bbb',
+                color: isActive ? 'var(--color-primary)' : isCompleted ? '#888' : '#bbb',
                 fontWeight: isActive ? 600 : 400,
               }}
             >

--- a/src/components/TestimonialCard/TestimonialCard.css
+++ b/src/components/TestimonialCard/TestimonialCard.css
@@ -23,7 +23,7 @@
   height: 80px;
   border-radius: 50%;
   object-fit: cover;
-  border: 3px solid #fd1c79;
+  border: 3px solid var(--color-primary);
 }
 
 .testimonial-card .stars {
@@ -31,7 +31,7 @@
   justify-content: center;
   gap: 4px;
   margin-bottom: 1rem;
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .testimonial-card blockquote {
@@ -44,7 +44,7 @@
 .testimonial-card h4 {
   font-weight: bold;
   font-size: 1.1rem;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 0.25rem;
 }
 

--- a/src/containers/about/About.css
+++ b/src/containers/about/About.css
@@ -1,6 +1,6 @@
 .about-section {
   padding: 4rem 0;
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
 }
 
 .about-container {
@@ -41,11 +41,11 @@
   font-size: 1.875rem;
   font-weight: 700;
   margin-bottom: 1.5rem;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .about-text {
-  color: #6c757d;
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
 }
 
@@ -68,27 +68,27 @@
 }
 
 .feature-icon {
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-right: 0.75rem;
   margin-top: 0.25rem;
 }
 
 .feature-title {
   font-weight: 600;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 0.25rem;
 }
 
 .feature-description {
   font-size: 0.875rem;
-  color: #6c757d;
+  color: var(--color-text-muted);
 }
 
 .about-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
 }
 
 .about-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }

--- a/src/containers/footer/Footer.css
+++ b/src/containers/footer/Footer.css
@@ -1,5 +1,5 @@
 .footer {
-  background-color: #2c3e50;
+  background-color: var(--color-text-dark);
   color: white;
   padding-top: 4rem;
 }
@@ -50,14 +50,14 @@
 }
 
 .footer-subscribe-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   white-space: nowrap;
   cursor: pointer;
 }
 
 .footer-subscribe-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 .footer-contact li,
@@ -74,7 +74,7 @@
 }
 
 .footer-icon {
-  color: #fd1c79;
+  color: var(--color-primary);
   flex-shrink: 0;
 }
 
@@ -90,7 +90,7 @@
 }
 
 .footer-social a:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .footer-bottom {

--- a/src/containers/gallery/Gallery.css
+++ b/src/containers/gallery/Gallery.css
@@ -17,11 +17,11 @@
 .gallery-header h2 {
   font-size: 1.875rem;
   font-weight: bold;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .gallery-header p {
-  color: #6c757d;
+  color: var(--color-text-muted);
   max-width: 600px;
   margin: 1rem auto 0;
 }
@@ -29,7 +29,7 @@
 .divider {
   width: 5rem;
   height: 0.25rem;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   margin: 1rem auto 0;
 }
 

--- a/src/containers/gift-cards/GiftCards.css
+++ b/src/containers/gift-cards/GiftCards.css
@@ -1,6 +1,6 @@
 .giftcards-section {
   padding: 4rem 0;
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
 }
 
 .giftcards-container {
@@ -48,25 +48,25 @@
 .follow-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 1rem;
 }
 
 .follow-handle {
   font-size: 2rem;
   font-weight: 700;
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-bottom: 1.5rem;
 }
 
 .follow-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   cursor: pointer;
 }
 
 .follow-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 .promo-title {
@@ -84,7 +84,7 @@
 
 .promo-button {
   background-color: white;
-  color: #fd1c79;
+  color: var(--color-primary);
   cursor: pointer;
 }
 

--- a/src/containers/hero/Hero.css
+++ b/src/containers/hero/Hero.css
@@ -64,7 +64,7 @@
 }
 
 .hero-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   padding: 1rem 2rem;
   font-size: 1.125rem;
@@ -73,7 +73,7 @@
 }
 
 .hero-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 .hero-indicators {

--- a/src/containers/latest-news/LatestNews.css
+++ b/src/containers/latest-news/LatestNews.css
@@ -1,6 +1,6 @@
 .latest-news {
   padding: 4rem 0;
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
 }
 
 .latest-news .container {
@@ -17,18 +17,18 @@
 .latest-news-header h2 {
   font-size: 1.875rem;
   font-weight: bold;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .latest-news-header .underline {
   width: 5rem;
   height: 0.25rem;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   margin: 1rem auto 0;
 }
 
 .latest-news-header p {
-  color: #6c757d;
+  color: var(--color-text-muted);
   margin-top: 1rem;
   max-width: 640px;
   margin-left: auto;
@@ -53,7 +53,7 @@
 }
 
 .cta-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   padding: 0.75rem 2rem;
   border: none;
@@ -63,7 +63,7 @@
 }
 
 .cta-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 /* BlogCard styles */
@@ -88,7 +88,7 @@
   position: absolute;
   top: 1rem;
   left: 1rem;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   font-size: 0.875rem;
   font-weight: 500;
@@ -104,22 +104,22 @@
   font-size: 1.25rem;
   font-weight: bold;
   margin-bottom: 0.75rem;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   transition: color 0.3s;
   text-decoration: none;
 }
 
 .blog-card-title:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .blog-card-excerpt {
-  color: #6c757d;
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
 }
 
 .blog-card-read-more {
-  color: #fd1c79;
+  color: var(--color-primary);
   font-weight: 500;
   text-decoration: none;
 }

--- a/src/containers/nail-care/NailCare.css
+++ b/src/containers/nail-care/NailCare.css
@@ -47,7 +47,7 @@
 
 .nailcare-button {
   background-color: white;
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .nailcare-button:hover {

--- a/src/containers/pricing/Pricing.css
+++ b/src/containers/pricing/Pricing.css
@@ -1,11 +1,4 @@
-:root {
-  --primary-color: #fd1c79;
-  --primary-hover: #e01968;
-  --text-dark: #2c3e50;
-  --text-light: #6c757d;
-  --bg-light: #f9fafb;
-}
-
+/* relies on CSS variables defined in globals.css */
 /* SECTION */
 .pricing-section {
   padding: 4rem 0;
@@ -26,19 +19,19 @@
 .pricing-header h2 {
   font-size: 1.875rem;
   font-weight: bold;
-  color: var(--text-dark);
+  color: var(--color-text-dark);
 }
 
 .divider {
   width: 5rem;
   height: 0.25rem;
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   margin: 1rem auto 0;
 }
 
 .pricing-header p {
   margin-top: 1rem;
-  color: var(--text-light);
+  color: var(--color-text-muted);
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
@@ -67,12 +60,12 @@
 }
 
 .price-card.popular {
-  border: 2px solid var(--primary-color);
+  border: 2px solid var(--color-primary);
   transform: scale(1.05);
 }
 
 .ribbon {
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
   font-size: 0.875rem;
   font-weight: 500;
@@ -90,13 +83,13 @@
   font-size: 1.25rem;
   font-weight: 700;
   margin-bottom: 1rem;
-  color: var(--text-dark);
+  color: var(--color-text-dark);
 }
 
 .card-price {
   font-size: 2rem;
   font-weight: 700;
-  color: var(--primary-color);
+  color: var(--color-primary);
   margin-bottom: 1.5rem;
 }
 
@@ -112,11 +105,11 @@
   align-items: flex-start;
   gap: 0.5rem;
   margin-bottom: 0.75rem;
-  color: var(--text-light);
+  color: var(--color-text-muted);
 }
 
 .check-icon {
-  color: var(--primary-color);
+  color: var(--color-primary);
   margin-top: 0.25rem;
 }
 
@@ -130,17 +123,17 @@
 }
 
 .card-button.primary {
-  background-color: var(--primary-color);
+  background-color: var(--color-primary);
   color: white;
 }
 
 .card-button.primary:hover {
-  background-color: var(--primary-hover);
+  background-color: var(--color-primary-hover);
 }
 
 .card-button.secondary {
   background-color: #f3f4f6;
-  color: var(--text-dark);
+  color: var(--color-text-dark);
 }
 
 .card-button.secondary:hover {
@@ -154,14 +147,14 @@
 }
 
 .pricing-cta p {
-  color: var(--text-light);
+  color: var(--color-text-muted);
   margin-bottom: 1rem;
 }
 
 .pricing-link {
   background: none;
   border: none;
-  color: var(--primary-color);
+  color: var(--color-primary);
   font-weight: 500;
   cursor: pointer;
 }

--- a/src/containers/promotions/Promotions.css
+++ b/src/containers/promotions/Promotions.css
@@ -52,12 +52,12 @@
 }
 
 .promo-button {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
 }
 
 .promo-button:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 .promotions-logos {

--- a/src/containers/services/Services.css
+++ b/src/containers/services/Services.css
@@ -17,19 +17,19 @@
 .services-heading h2 {
   font-size: 2rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .services-heading .underline {
   width: 60px;
   height: 4px;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   margin: 0.5rem auto 1rem;
 }
 
 .services-heading p {
   font-size: 1rem;
-  color: #6c757d;
+  color: var(--color-text-muted);
 }
 
 .services-grid {
@@ -53,18 +53,18 @@
 }
 
 .service-icon {
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-bottom: 1rem;
 }
 
 .service-title {
   font-size: 1.25rem;
   font-weight: 600;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 0.75rem;
 }
 
 .service-description {
-  color: #6c757d;
+  color: var(--color-text-muted);
   font-size: 1rem;
 }

--- a/src/containers/skilled-nail-art/SkilledNailArt.css
+++ b/src/containers/skilled-nail-art/SkilledNailArt.css
@@ -27,7 +27,7 @@
 }
 
 .skilled-tag {
-  color: #fd1c79;
+  color: var(--color-primary);
   font-size: 1.125rem;
   font-weight: 500;
 }
@@ -35,7 +35,7 @@
 .skilled-heading {
   font-size: 2rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-top: 0.5rem;
   margin-bottom: 1.5rem;
 }
@@ -47,12 +47,12 @@
 }
 
 .skilled-description {
-  color: #6c757d;
+  color: var(--color-text-muted);
   font-size: 1.125rem;
 }
 
 .skilled-panel .panel-box {
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
   padding: 2rem;
   border-radius: 0.5rem;
 }
@@ -60,10 +60,10 @@
 .panel-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: #2c3e50;
+  color: var(--color-text-dark);
   margin-bottom: 1rem;
 }
 
 .panel-text {
-  color: #6c757d;
+  color: var(--color-text-muted);
 }

--- a/src/containers/testimonials/Testimonials.css
+++ b/src/containers/testimonials/Testimonials.css
@@ -1,6 +1,6 @@
 .testimonials-section {
   padding: 4rem 0;
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
 }
 
 .testimonials-container {
@@ -17,13 +17,13 @@
 .section-header h2 {
   font-size: 1.875rem;
   font-weight: bold;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .section-divider {
   width: 5rem;
   height: 0.25rem;
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   margin: 1rem auto 0;
 }
 
@@ -78,7 +78,7 @@
 }
 
 blockquote {
-  color: #6c757d;
+  color: var(--color-text-muted);
   font-style: italic;
   margin-bottom: 1.5rem;
 }
@@ -86,11 +86,11 @@ blockquote {
 .testimonial-card h4 {
   font-weight: bold;
   font-size: 1.125rem;
-  color: #2c3e50;
+  color: var(--color-text-dark);
 }
 
 .testimonial-card p {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .nav-button {
@@ -101,12 +101,12 @@ blockquote {
   padding: 0.5rem;
   border-radius: 9999px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
-  color: #6c757d;
+  color: var(--color-text-muted);
   transition: color 0.3s ease;
 }
 
 .nav-button:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .nav-button.left {
@@ -135,13 +135,13 @@ blockquote {
 }
 
 .dot.active {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   transform: scale(1.25);
 }
 
 .testimonials-section {
   padding: 4rem 0;
-  background-color: #f9fafb;
+  background-color: var(--color-bg-light);
 }
 
 .testimonial-swiper {

--- a/src/globals.css
+++ b/src/globals.css
@@ -22,6 +22,12 @@
     --destructive: 0 100% 50%;
     --destructive-foreground: 210 40% 98%;
     --ring: 215 20.2% 65.1%;
+    /* Hex color references for global use */
+    --color-primary: #fd1c79;
+    --color-primary-hover: #e01968;
+    --color-text-dark: #2c3e50;
+    --color-text-muted: #6c757d;
+    --color-bg-light: #f9fafb;
     --radius: 0.5rem;
   }
 

--- a/src/pages/BookingPage/BookingPage.css
+++ b/src/pages/BookingPage/BookingPage.css
@@ -11,7 +11,7 @@
 .booking-header {
   width: 100%;
   padding-bottom: 1.5rem;
-  border-bottom: 2px solid #fd1c79;
+  border-bottom: 2px solid var(--color-primary);
   margin-bottom: 2rem;
 }
 
@@ -19,7 +19,7 @@
   margin: 0 0 1rem 0;
   font-size: 2rem;
   font-weight: 600;
-  color: #fd1c79;
+  color: var(--color-primary);
   text-align: center;
 }
 
@@ -40,7 +40,7 @@
 
 .booking-title {
   font-size: 1.8rem;
-  color: #fd1c79;
+  color: var(--color-primary);
   font-weight: 600;
   text-align: left;
 }
@@ -54,7 +54,7 @@
 }
 
 .booking-submit {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   padding: 0.9rem;
   border-radius: 8px;
@@ -68,7 +68,7 @@
 }
 
 .booking-submit:hover {
-  background-color: #e01968;
+  background-color: var(--color-primary-hover);
 }
 
 /* Step Progress Bar */
@@ -90,7 +90,7 @@
 }
 
 .step-circle {
-  background-color: #fd1c79;
+  background-color: var(--color-primary);
   color: white;
   font-weight: bold;
   border-radius: 50%;

--- a/src/pages/ContactUsPage/ContactUsPage.css
+++ b/src/pages/ContactUsPage/ContactUsPage.css
@@ -19,7 +19,7 @@
   font-size: 2.7rem;
   font-family: 'Playfair Display', serif;
   font-weight: 700;
-  color: #fd1c79;
+  color: var(--color-primary);
   letter-spacing: 1px;
   margin-bottom: 0.3rem;
 }
@@ -61,7 +61,7 @@
 }
 
 .newsletter-title {
-  color: #fd1c79;
+  color: var(--color-primary);
   font-size: 1.18rem;
   font-weight: 700;
   margin-bottom: 0.35rem;
@@ -82,7 +82,7 @@
   flex: 1;
   background: #18181c;
   color: #fff;
-  border: 1px solid #fd1c79;
+  border: 1px solid var(--color-primary);
   border-radius: 8px;
   padding: 0.7rem 1rem;
   font-size: 1rem;
@@ -90,7 +90,7 @@
 }
 
 .newsletter-btn {
-  background: #fd1c79;
+  background: var(--color-primary);
   color: #fff;
   font-weight: 700;
   border-radius: 8px;
@@ -121,7 +121,7 @@
 .contact-subtitle {
   font-size: 1.09rem;
   font-weight: 600;
-  color: #fd1c79;
+  color: var(--color-primary);
   margin-bottom: 0.3rem;
   letter-spacing: 0.5px;
 }
@@ -140,7 +140,7 @@
   transition: color 0.2s;
 }
 .contact-row a:hover {
-  color: #fd1c79;
+  color: var(--color-primary);
 }
 
 .contact-hours {
@@ -170,7 +170,7 @@
 }
 
 .footer-links a {
-  color: #fd1c79;
+  color: var(--color-primary);
   margin: 0 0.35em;
   text-decoration: underline;
   font-weight: 500;

--- a/src/pages/GiftCardPage/GiftCardPage.css
+++ b/src/pages/GiftCardPage/GiftCardPage.css
@@ -18,7 +18,7 @@
 }
 
 .giftcard-title {
-  color: #fd1c79;
+  color: var(--color-primary);
   font-size: 2.1rem;
   margin-bottom: 0.7rem;
   font-weight: 700;
@@ -47,9 +47,9 @@
 }
 
 .giftcard-amount-btn {
-  border: 1.5px solid #fd1c79;
+  border: 1.5px solid var(--color-primary);
   background: #fff;
-  color: #fd1c79;
+  color: var(--color-primary);
   font-size: 1rem;
   font-weight: 600;
   padding: 0.7rem 1.5rem;
@@ -59,7 +59,7 @@
 }
 .giftcard-amount-btn.selected,
 .giftcard-amount-btn:hover {
-  background: #fd1c79;
+  background: var(--color-primary);
   color: #fff;
 }
 
@@ -75,7 +75,7 @@
 
 .giftcard-purchase-btn {
   width: 100%;
-  background: #fd1c79;
+  background: var(--color-primary);
   color: #fff;
   font-size: 1.09rem;
   border-radius: 7px;

--- a/src/pages/ServicesPage/ServicesPage.css
+++ b/src/pages/ServicesPage/ServicesPage.css
@@ -155,7 +155,7 @@
   margin-bottom: 2rem;
 }
 .services-booking-btn {
-  background: #fd1c79;
+  background: var(--color-primary);
   color: #fff;
   padding: 1.2rem 3.5rem;
   font-size: 1.12rem;
@@ -165,5 +165,5 @@
   cursor: pointer;
 }
 .services-booking-btn:hover {
-  background: #e01968;
+  background: var(--color-primary-hover);
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -43,6 +43,11 @@ module.exports = {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        brand: "var(--color-primary)",
+        brandHover: "var(--color-primary-hover)",
+        textDark: "var(--color-text-dark)",
+        textMuted: "var(--color-text-muted)",
+        bgLight: "var(--color-bg-light)",
       },
       borderRadius: {
         lg: `var(--radius)`,


### PR DESCRIPTION
## Summary
- define global hex color variables in `globals.css`
- remove local CSS overrides in Pricing
- use the new variables across styles and components
- map Tailwind color names to the new variables

## Testing
- `npm run typecheck`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f71a9d2a083308b1e1be8391a1c73