### PR TITLE
Improve lighthouse performance hints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,11 +8,13 @@ import About from './containers/about/About';
 import Testimonials from './containers/testimonials/Testimonials';
 import Gallery from './containers/gallery/Gallery';
 import GiftCards from './containers/gift-cards/GiftCards';
-import BookingPage from './pages/BookingPage/BookingPage';
-import ServicesPage from './pages/ServicesPage/ServicesPage';
-import TeamPage from './pages/TeamPage/TeamPage';
-import ContactUsPage from './pages/ContactUsPage/ContactUsPage';
-import GiftCardPage from './pages/GiftCardPage/GiftCardPage';
+import { lazy, Suspense } from 'react';
+
+const BookingPage = lazy(() => import('./pages/BookingPage/BookingPage'));
+const ServicesPage = lazy(() => import('./pages/ServicesPage/ServicesPage'));
+const TeamPage = lazy(() => import('./pages/TeamPage/TeamPage'));
+const ContactUsPage = lazy(() => import('./pages/ContactUsPage/ContactUsPage'));
+const GiftCardPage = lazy(() => import('./pages/GiftCardPage/GiftCardPage'));
 
 const pageTransition = {
   initial: { opacity: 0, y: 30 },
@@ -99,7 +101,9 @@ function App() {
       <div className="flex flex-col min-h-screen">
         <Header />
         <main className="flex-grow">
-          <AnimatedRoutes />
+          <Suspense fallback={<div>Loading...</div>}>
+            <AnimatedRoutes />
+          </Suspense>
         </main>
         <Footer />
       </div>

--- a/src/components/BlogCard/BlogCard.tsx
+++ b/src/components/BlogCard/BlogCard.tsx
@@ -11,10 +11,11 @@ const BlogCard = ({ image, date, title, excerpt }: BlogCardProps) => {
   return (
     <div className="blog-card">
       <div className="blog-card-image-wrapper">
-        <img 
-          src={image} 
-          alt={title} 
+        <img
+          src={image}
+          alt={title}
           className="blog-card-image"
+          loading="lazy"
         />
         <div className="blog-card-date">
           {date}

--- a/src/components/DesignerSelector/DesignerSelector.tsx
+++ b/src/components/DesignerSelector/DesignerSelector.tsx
@@ -25,6 +25,7 @@ const DesignerSelector = ({ value, onChange }: Props) => {
               src={designer.avatar}
               alt={designer.name}
               className="designer-avatar"
+              loading="lazy"
             />
             <div>
               <h4 className="designer-name">{designer.name}</h4>

--- a/src/components/GalleryCard/GalleryCard.tsx
+++ b/src/components/GalleryCard/GalleryCard.tsx
@@ -23,7 +23,7 @@ const GalleryCard = ({ src, alt, onClick }: GalleryCardProps) => {
       animate="initial"
       style={{ cursor: "pointer", overflow: "hidden", position: "relative" }}
     >
-      <img src={src} alt={alt} style={{ width: "100%", height: "auto", display: "block", borderRadius: "8px" }} />
+      <img src={src} alt={alt} loading="lazy" style={{ width: "100%", height: "auto", display: "block", borderRadius: "8px" }} />
       <motion.figcaption
         className="gallery-overlay"
         variants={overlayVariants}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -31,7 +31,7 @@ const Header = () => {
     >
       <div className="header-container">
         <Link to="/" className="logo">
-          <img src={logo192} alt="Logo" className="logo-img" />
+          <img src={logo192} alt="Logo" className="logo-img" loading="lazy" />
           {headerContent.logoText}
         </Link>
         <nav className="desktop-nav">

--- a/src/components/OurServiceCard/OurServiceCard.tsx
+++ b/src/components/OurServiceCard/OurServiceCard.tsx
@@ -44,7 +44,7 @@ const OurServiceCard: React.FC<OurServiceCardProps> = ({
     <div className="our-card">
       {image && (
         <div className="our-card-img">
-          <img src={image} alt={title} />
+          <img src={image} alt={title} loading="lazy" />
         </div>
       )}
       <div className="our-card-content">

--- a/src/components/ServiceCard/ServiceCard.tsx
+++ b/src/components/ServiceCard/ServiceCard.tsx
@@ -13,7 +13,7 @@ const ServiceCard = ({ title, image, description }: ServiceCardProps) => {
   return (
     <div className="service-card">
       <div className="service-image">
-        <img src={image} alt={title} />
+        <img src={image} alt={title} loading="lazy" />
       </div>
 
       <div className="service-content">

--- a/src/components/TeammateCard/TeammateCard.tsx
+++ b/src/components/TeammateCard/TeammateCard.tsx
@@ -10,7 +10,7 @@ export interface TeammateCardProps {
 
 const TeammateCard: React.FC<TeammateCardProps> = ({ name, title, avatar, bio }) => (
   <div className="teammate-card">
-    <img src={avatar} alt={name} className="teammate-avatar" />
+    <img src={avatar} alt={name} className="teammate-avatar" loading="lazy" />
     <div className="teammate-name">{name}</div>
     <div className="teammate-title">{title}</div>
     <div className="teammate-bio">{bio}</div>

--- a/src/components/TestimonialCard/TestimonialCard.tsx
+++ b/src/components/TestimonialCard/TestimonialCard.tsx
@@ -14,7 +14,7 @@ const TestimonialCard = ({ name, role, image, quote, rating }: TestimonialCardPr
   return (
     <div className="testimonial-card">
       <div className="avatar">
-        <img src={image} alt={name} />
+        <img src={image} alt={name} loading="lazy" />
       </div>
       <div className="stars">
         {[...Array(rating)].map((_, i) => (

--- a/src/containers/about/About.tsx
+++ b/src/containers/about/About.tsx
@@ -11,7 +11,7 @@ const About = () => {
       <div className="about-container">
         <div className="about-grid">
           <div className="about-image-wrapper">
-            <img src={image.src} alt={image.alt} className="about-image" />
+            <img src={image.src} alt={image.alt} className="about-image" loading="lazy" />
           </div>
 
           <div className="about-content">

--- a/src/containers/gallery/Gallery.tsx
+++ b/src/containers/gallery/Gallery.tsx
@@ -95,6 +95,7 @@ const Gallery = () => {
         src={selectedImage}
         alt="Enlarged nail design"
         style={{ maxWidth: "90vw", maxHeight: "80vh", borderRadius: "12px" }}
+        loading="lazy"
       />
     </motion.div>
   </div>

--- a/src/containers/promotions/Promotions.tsx
+++ b/src/containers/promotions/Promotions.tsx
@@ -29,6 +29,7 @@ const Promotions = () => {
                 src={logo}
                 alt={`Partner logo ${index + 1}`}
                 className="partner-logo"
+                loading="lazy"
               />
             ))}
           </div>

--- a/src/data/content.tsx
+++ b/src/data/content.tsx
@@ -1,8 +1,8 @@
 import { url } from "inspector";
-import img1 from '@/assets/nail-gallery/1.webp';
-import img2 from '@/assets/nail-gallery/2.webp';
-import img3 from '@/assets/nail-gallery/3.webp';
-import img4 from '@/assets/nail-gallery/4.webp';
+import img1 from '@/assets/nail-salon/1.jpg';
+import img2 from '@/assets/nail-salon/2.jpg';
+import img3 from '@/assets/nail-salon/3.jpg';
+import img4 from '@/assets/nail-salon/4.jpg';
 
 // src/headerContent.tsx
 export const headerContent = {

--- a/src/data/content.tsx
+++ b/src/data/content.tsx
@@ -1,8 +1,8 @@
 import { url } from "inspector";
-import img1 from '@/assets/nail-salon/1.jpg';
-import img2 from '@/assets/nail-salon/2.jpg';
-import img3 from '@/assets/nail-salon/3.jpg';
-import img4 from '@/assets/nail-salon/4.jpg';
+import img1 from '@/assets/nail-gallery/1.webp';
+import img2 from '@/assets/nail-gallery/2.webp';
+import img3 from '@/assets/nail-gallery/3.webp';
+import img4 from '@/assets/nail-gallery/4.webp';
 
 // src/headerContent.tsx
 export const headerContent = {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,9 +7,9 @@ export default defineConfig({
   plugins: [react(), tailwindcss()],
   base: "./",
   build: {
-    minify: false,
+    minify: true,
     sourcemap: false,
-    cssCodeSplit: false,
+    cssCodeSplit: true,
     target: "esnext",
     ssr: false,
   },


### PR DESCRIPTION
## Summary
- enable build minification and CSS code splitting
- load hero slides from WebP images
- mark images as lazy loaded
- load pages lazily with `React.lazy`

## Testing
- `npm run typecheck` *(fails: Cannot find module 'clsx' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_683f771aa7608330a59d444604050ac3