### PR TITLE
Add payment page route

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import GiftCards from './containers/gift-cards/GiftCards';
 import { lazy, Suspense } from 'react';
 
 const BookingPage = lazy(() => import('./pages/BookingPage/BookingPage'));
+const PaymentPage = lazy(() => import('./pages/PaymentPage/PaymentPage'));
 const ServicesPage = lazy(() => import('./pages/ServicesPage/ServicesPage'));
 const TeamPage = lazy(() => import('./pages/TeamPage/TeamPage'));
 const ContactUsPage = lazy(() => import('./pages/ContactUsPage/ContactUsPage'));
@@ -49,6 +50,14 @@ function AnimatedRoutes() {
           element={
             <motion.div {...pageTransition}>
               <BookingPage />
+            </motion.div>
+          }
+        />
+        <Route
+          path="/payment"
+          element={
+            <motion.div {...pageTransition}>
+              <PaymentPage />
             </motion.div>
           }
         />

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import './BookingPage.css';
 import ServiceCategorySelector from '@/components/ServiceCategorySelector/ServiceCategorySelector';
 import ServiceSelector from '@/components/ServiceSelector/ServiceSelector';
@@ -22,6 +22,7 @@ const steps = [
 
 const BookingPage = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const navState = location.state || {};
 
   const [formData, setFormData] = useState({
@@ -111,7 +112,7 @@ const BookingPage = () => {
       },
     ]);
     setShowReview(false);
-    alert(`Appointment booked on ${formData.start?.toLocaleString()}`);
+    navigate('/payment', { state: { formData } });
     setStep(0);
     setFormData({ category: '', service: '', designer: '', start: null, end: null });
   };

--- a/src/pages/PaymentPage/PaymentPage.css
+++ b/src/pages/PaymentPage/PaymentPage.css
@@ -1,0 +1,57 @@
+.payment-bg {
+  min-height: 100vh;
+  background: #fff1e6;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 0;
+}
+
+.payment-form {
+  background: #fff;
+  border-radius: 18px;
+  box-shadow: 0 8px 32px rgba(32, 48, 60, 0.13);
+  width: 100%;
+  max-width: 420px;
+  padding: 2rem 2rem 2.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.payment-title {
+  color: var(--color-primary);
+  font-size: 2rem;
+  font-weight: 700;
+  text-align: center;
+  margin-bottom: 0.5rem;
+}
+
+.payment-summary {
+  background: var(--color-bg-light);
+  border-radius: 8px;
+  padding: 1rem;
+  font-size: 0.95rem;
+  color: var(--color-text-dark);
+}
+
+.payment-row {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.payment-button {
+  background: var(--color-primary);
+  color: #fff;
+}
+
+.payment-button:hover {
+  background: var(--color-primary-hover);
+}
+
+.payment-success {
+  text-align: center;
+  color: #22b573;
+  font-weight: 600;
+  margin-top: 0.5rem;
+}

--- a/src/pages/PaymentPage/PaymentPage.tsx
+++ b/src/pages/PaymentPage/PaymentPage.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { categoryServices } from '@/data/pricing';
+import './PaymentPage.css';
+
+const PaymentPage = () => {
+  const { state } = useLocation();
+  const navigate = useNavigate();
+  const booking = (state as any)?.formData;
+
+  const [name, setName] = useState('');
+  const [card, setCard] = useState('');
+  const [expiry, setExpiry] = useState('');
+  const [cvv, setCvv] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const getPrice = () => {
+    if (!booking) return '';
+    for (const cat of categoryServices) {
+      if (cat.title === booking.service) return `${cat.currency} ${cat.cost}`;
+      const svc = cat.services?.find(s => s.title === booking.service);
+      if (svc) return `${svc.currency} ${svc.cost}`;
+    }
+    return '';
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    setSubmitted(true);
+    setTimeout(() => navigate('/'), 1500);
+  };
+
+  return (
+    <div className="payment-bg">
+      <form className="payment-form" onSubmit={handleSubmit}>
+        <h1 className="payment-title">Payment</h1>
+
+        {booking && (
+          <div className="payment-summary">
+            <p><strong>Service:</strong> {booking.service}</p>
+            <p><strong>Artist:</strong> {booking.designer}</p>
+            {booking.start && (
+              <p><strong>Date:</strong> {new Date(booking.start).toLocaleString()}</p>
+            )}
+            {getPrice() && <p><strong>Price:</strong> {getPrice()}</p>}
+          </div>
+        )}
+
+        <Input
+          placeholder="Name on Card"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          required
+        />
+        <Input
+          placeholder="Card Number"
+          value={card}
+          onChange={e => setCard(e.target.value)}
+          required
+        />
+        <div className="payment-row">
+          <Input
+            placeholder="MM/YY"
+            value={expiry}
+            onChange={e => setExpiry(e.target.value)}
+            required
+          />
+          <Input
+            placeholder="CVV"
+            value={cvv}
+            onChange={e => setCvv(e.target.value)}
+            required
+          />
+        </div>
+        <Button type="submit" className="payment-button">
+          Pay Now
+        </Button>
+        {submitted && <div className="payment-success">Payment Successful!</div>}
+      </form>
+    </div>
+  );
+};
+
+export default PaymentPage;


### PR DESCRIPTION
## Summary
- add new payment page
- style payment page with main color theme
- navigate to payment page after booking confirmation

## Testing
- `npm run typecheck`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_683f9495aa448330a5cb32779e9deb0b