### PR TITLE
Connect front end to back end

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -2,3 +2,8 @@ const { TextEncoder, TextDecoder } = require('util');
 
 if (!global.TextEncoder) global.TextEncoder = TextEncoder;
 if (!global.TextDecoder) global.TextDecoder = TextDecoder;
+if (!global.fetch) {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve([]) })
+  );
+}

--- a/server/README.md
+++ b/server/README.md
@@ -42,6 +42,12 @@ details) and services.
 
 All API endpoints are mounted under `/api`.
 
+### Reviews and Gallery
+
+Customer testimonials can be retrieved from `/api/reviews`.
+
+Gallery images are available from `/api/gallery`.
+
 ### Transactions
 
 Financial operations are stored in a `Transaction` table. Routes are available under `/api/transactions` to create and list user transactions.

--- a/server/index.js
+++ b/server/index.js
@@ -2,9 +2,12 @@ import express from 'express';
 import dotenv from 'dotenv';
 import authRoutes from './routes/authRoutes.js';
 import serviceRoutes from './routes/serviceRoutes.js';
+import serviceCategoryRoutes from './routes/serviceCategoryRoutes.js';
 import designerRoutes from './routes/designerRoutes.js';
 import bookingRoutes from './routes/bookingRoutes.js';
 import transactionRoutes from './routes/transactionRoutes.js';
+import customerReviewRoutes from './routes/customerReviewRoutes.js';
+import galleryImageRoutes from './routes/galleryImageRoutes.js';
 
 dotenv.config();
 
@@ -13,9 +16,12 @@ app.use(express.json());
 
 app.use('/api', authRoutes);
 app.use('/api/services', serviceRoutes);
+app.use('/api/categories', serviceCategoryRoutes);
 app.use('/api/designers', designerRoutes);
 app.use('/api/bookings', bookingRoutes);
 app.use('/api/transactions', transactionRoutes);
+app.use('/api/reviews', customerReviewRoutes);
+app.use('/api/gallery', galleryImageRoutes);
 
 const PORT = process.env.PORT || 3001;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/models/customerReviewModel.js
+++ b/server/models/customerReviewModel.js
@@ -1,0 +1,5 @@
+import { prisma } from '../prisma/client.js';
+
+export function getAllCustomerReviews() {
+  return prisma.customerReview.findMany();
+}

--- a/server/models/galleryImageModel.js
+++ b/server/models/galleryImageModel.js
@@ -1,0 +1,5 @@
+import { prisma } from '../prisma/client.js';
+
+export function getAllGalleryImages() {
+  return prisma.galleryImage.findMany();
+}

--- a/server/models/serviceCategoryModel.js
+++ b/server/models/serviceCategoryModel.js
@@ -1,0 +1,5 @@
+import { prisma } from '../prisma/client.js';
+
+export function getAllServiceCategories() {
+  return prisma.serviceCategory.findMany({ include: { services: true } });
+}

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -81,3 +81,18 @@ model Transaction {
   status     String
   createdAt  DateTime @default(now())
 }
+
+model CustomerReview {
+  id       Int    @id @default(autoincrement())
+  name     String
+  role     String?
+  image    String?
+  quote    String
+  rating   Int
+}
+
+model GalleryImage {
+  id      Int    @id @default(autoincrement())
+  url     String
+  caption String?
+}

--- a/server/routes/customerReviewRoutes.js
+++ b/server/routes/customerReviewRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { listCustomerReviews } from '../services/customerReviewService.js';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  const reviews = await listCustomerReviews();
+  res.json(reviews);
+});
+
+export default router;

--- a/server/routes/galleryImageRoutes.js
+++ b/server/routes/galleryImageRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { listGalleryImages } from '../services/galleryImageService.js';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  const images = await listGalleryImages();
+  res.json(images);
+});
+
+export default router;

--- a/server/routes/serviceCategoryRoutes.js
+++ b/server/routes/serviceCategoryRoutes.js
@@ -1,0 +1,11 @@
+import express from 'express';
+import { listServiceCategories } from '../services/serviceCategoryService.js';
+
+const router = express.Router();
+
+router.get('/', async (_req, res) => {
+  const categories = await listServiceCategories();
+  res.json(categories);
+});
+
+export default router;

--- a/server/services/customerReviewService.js
+++ b/server/services/customerReviewService.js
@@ -1,0 +1,5 @@
+import { getAllCustomerReviews } from '../models/customerReviewModel.js';
+
+export function listCustomerReviews() {
+  return getAllCustomerReviews();
+}

--- a/server/services/galleryImageService.js
+++ b/server/services/galleryImageService.js
@@ -1,0 +1,5 @@
+import { getAllGalleryImages } from '../models/galleryImageModel.js';
+
+export function listGalleryImages() {
+  return getAllGalleryImages();
+}

--- a/server/services/serviceCategoryService.js
+++ b/server/services/serviceCategoryService.js
@@ -1,0 +1,5 @@
+import { getAllServiceCategories } from '../models/serviceCategoryModel.js';
+
+export function listServiceCategories() {
+  return getAllServiceCategories();
+}

--- a/src/components/DesignerSelector/DesignerSelector.tsx
+++ b/src/components/DesignerSelector/DesignerSelector.tsx
@@ -1,12 +1,13 @@
-import { designers } from '@/data/designers';
+import { designers as fallbackDesigners, type Designer } from '@/data/designers';
 import './DesignerSelector.css';
 
 interface Props {
   value: string;
   onChange: (e: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  designers?: Designer[];
 }
 
-const DesignerSelector = ({ value, onChange }: Props) => {
+const DesignerSelector = ({ value, onChange, designers }: Props) => {
   const handleSelect = (name: string) => {
     onChange({ target: { name: 'designer', value: name } } as any);
   };
@@ -15,7 +16,7 @@ const DesignerSelector = ({ value, onChange }: Props) => {
     <div className="designer-selector">
       <h3 className="designer-heading">Choose your artist</h3>
       <div className="designer-grid">
-        {designers.map((designer) => (
+        {(designers && designers.length ? designers : fallbackDesigners).map((designer) => (
           <div
             key={designer.name}
             className={`designer-card${value === designer.name ? ' selected' : ''}`}

--- a/src/components/ServiceCategorySelector/ServiceCategorySelector.tsx
+++ b/src/components/ServiceCategorySelector/ServiceCategorySelector.tsx
@@ -1,36 +1,39 @@
-import { categoryServices } from '@/data/pricing';
+import { categoryServices, type CategoryServiceItem } from '@/data/pricing';
 import ClockIcon from "../icons/ClockIcon";
 // import './ServiceCategorySelector.css';
 
 interface Props {
   value: string;
   onChange: (category: string) => void;
+  categories?: CategoryServiceItem[];
 }
 
-const ServiceCategorySelector = ({ value, onChange }: Props) => {
+const ServiceCategorySelector = ({ value, onChange, categories }: Props) => {
   const handleSelect = (title: string) => {
     onChange(title); // Only pass the string title!
   };
 
+  const data = categories && categories.length ? categories : categoryServices;
+
   const getPricingInfo = (title: string) =>
-    categoryServices.find((s) => s.title === title);
+    data.find((s) => s.title === title || s.name === title);
 
   return (
     <div className="service-selector">
       <h3 className="service-selector-heading">Select a category service</h3>
 
       <div className="service-selector-grid">
-        {categoryServices.map((service) => {
-          const pricing = getPricingInfo(service.title);
+        {data.map((service) => {
+          const pricing = getPricingInfo(service.title || service.name);
 
           return (
             <div
-              key={service.title}
-              className={`service-selector-card ${value === service.title ? 'selected' : ''}`}
-              onClick={() => handleSelect(service.title)}
+              key={service.title || service.name}
+              className={`service-selector-card ${value === (service.title || service.name) ? 'selected' : ''}`}
+              onClick={() => handleSelect(service.title || service.name)}
             >
               <h4 className="service-selector-title">
-                {service.title} - ${pricing?.cost}
+                {(service.title || service.name)} - ${pricing?.cost}
               </h4>
               <p className="service-selector-description">{service.description}</p>
 

--- a/src/components/ServiceSelector/ServiceSelector.tsx
+++ b/src/components/ServiceSelector/ServiceSelector.tsx
@@ -1,5 +1,5 @@
 // src/components/ServiceSelector/ServiceSelector.tsx
-import { categoryServices } from '@/data/pricing';
+import { categoryServices, type CategoryServiceItem } from '@/data/pricing';
 import './ServiceSelector.css';
 import ClockIcon from "../icons/ClockIcon";
 
@@ -7,14 +7,16 @@ interface Props {
   value: string;
   category: string;
   onChange: (e: React.ChangeEvent<HTMLSelectElement> | string) => void;
+  categories?: CategoryServiceItem[];
 }
 
-const ServiceSelector = ({ value, category, onChange }: Props) => {
+const ServiceSelector = ({ value, category, onChange, categories }: Props) => {
   const handleSelect = (title: string) => {
     onChange({ target: { name: 'service', value: title } } as any);
   };
 
-  const selectedCategory = categoryServices.find(cat => cat.title === category);
+  const data = categories && categories.length ? categories : categoryServices;
+  const selectedCategory = data.find(cat => (cat.title || cat.name) === category);
 
   return (
     <div className="service-selector">
@@ -26,16 +28,20 @@ const ServiceSelector = ({ value, category, onChange }: Props) => {
         <div className="service-selector-grid">
           {selectedCategory.services.map((service) => (
             <div
-              key={service.title}
-              className={`service-selector-card ${value === service.title ? 'selected' : ''}`}
-              onClick={() => handleSelect(service.title)}
+              key={service.title || service.name}
+              className={`service-selector-card ${value === (service.title || service.name) ? 'selected' : ''}`}
+              onClick={() => handleSelect(service.title || service.name)}
             >
-              <h4 className="service-selector-title">{service.title} - ${service.cost}</h4>
+              <h4 className="service-selector-title">{(service.title || service.name)} - ${service.cost ?? service.price}</h4>
               <p className="service-selector-description">{service.description}</p>
               <div className="service-selector-meta">
                 <p style={{ display: "flex", alignItems: "center", gap: 4 }}>
                   <ClockIcon size={16} color="#bbb" style={{ marginRight: 4, flexShrink: 0 }} />
-                  {service.estimatedTimeMinutesRange[0]}–{service.estimatedTimeMinutesRange[1]} mins
+                  {service.estimatedTimeMinutesRange ? (
+                    `${service.estimatedTimeMinutesRange[0]}–${service.estimatedTimeMinutesRange[1]} mins`
+                  ) : (
+                    `${service.duration} mins`
+                  )}
                 </p>
               </div>
             </div>

--- a/src/containers/services/Services.tsx
+++ b/src/containers/services/Services.tsx
@@ -3,8 +3,28 @@ import ServiceCard from '../../components/ServiceCard/ServiceCard';
 import { Button } from '@/components/ui/button';
 import './Services.css';
 import { servicesContent } from '@/data/content';
+import { type CategoryServiceItem } from '@/data/pricing';
+import { useEffect, useState } from 'react';
 
 const ServicesSection = () => {
+  const [categories, setCategories] = useState<CategoryServiceItem[]>([]);
+
+  useEffect(() => {
+    fetch('/api/categories')
+      .then(res => res.json())
+      .then(setCategories)
+      .catch(() => {});
+  }, []);
+
+  const items =
+    categories.length > 0
+      ? categories.map(cat => ({
+          title: cat.name || cat.title,
+          image: cat.image,
+          description: cat.description,
+        }))
+      : servicesContent.items;
+
   return (
     <section className="services-section">
       <div className="services-container">
@@ -14,7 +34,7 @@ const ServicesSection = () => {
         </div>
 
         <div className="services-grid">
-          {servicesContent.items.map((service, index) => (
+          {items.map((service, index) => (
             <ServiceCard key={index} {...service} />
           ))}
         </div>

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -9,6 +9,8 @@ import StepProgressBar from '@/components/StepProgressBar/StepProgressBar';
 import ReviewModal from '@/components/ReviewModal/ReviewModal';
 import SidebarMask from '@/components/SidebarMask/SidebarMask';
 import { getDummyBookings, BookingEvent } from '@/data/availableSlots';
+import { categoryServices, type CategoryServiceItem } from '@/data/pricing';
+import { designers as fallbackDesigners, type Designer } from '@/data/designers';
 import { motion, AnimatePresence } from "framer-motion";
 import { useIsMobile } from '@/lib/useIsMobile'; // import the custom hook
 
@@ -24,6 +26,9 @@ const BookingPage = () => {
   const location = useLocation();
   const navState = location.state || {};
 
+  const [categories, setCategories] = useState<CategoryServiceItem[]>([]);
+  const [designerData, setDesignerData] = useState<Designer[]>([]);
+
   const [formData, setFormData] = useState({
     category: '',
     service: '',
@@ -35,6 +40,17 @@ const BookingPage = () => {
   const [step, setStep] = useState(0);
   const [showReview, setShowReview] = useState(false);
   const isMobile = useIsMobile(); // <-- use the custom hook
+
+  useEffect(() => {
+    fetch('/api/categories')
+      .then(res => res.json())
+      .then(setCategories)
+      .catch(() => setCategories([]));
+    fetch('/api/designers')
+      .then(res => res.json())
+      .then(setDesignerData)
+      .catch(() => setDesignerData([]));
+  }, []);
 
   useEffect(() => {
     if (navState.category) {
@@ -55,6 +71,9 @@ const BookingPage = () => {
   useEffect(() => {
     setEvents(getDummyBookings());
   }, []);
+
+  const categorySource = categories.length ? categories : categoryServices;
+  const designerSource = designerData.length ? designerData : fallbackDesigners;
 
   const goToStep = (targetStep: number) => {
     setStep(targetStep);
@@ -150,7 +169,7 @@ const BookingPage = () => {
                       exit={{ opacity: 0, x: 32 }}
                       transition={{ duration: 0.24 }}
                     >
-                      <ServiceCategorySelector value={formData.category} onChange={handleCategoryChange} />
+                      <ServiceCategorySelector categories={categorySource} value={formData.category} onChange={handleCategoryChange} />
                     </motion.div>
                   )}
                   {step === 1 && (
@@ -161,7 +180,7 @@ const BookingPage = () => {
                       exit={{ opacity: 0, x: 32 }}
                       transition={{ duration: 0.24 }}
                     >
-                      <ServiceSelector value={formData.service} category={formData.category} onChange={handleServiceChange} />
+                      <ServiceSelector categories={categorySource} value={formData.service} category={formData.category} onChange={handleServiceChange} />
                     </motion.div>
                   )}
                   {step === 2 && (
@@ -172,7 +191,7 @@ const BookingPage = () => {
                       exit={{ opacity: 0, x: 32 }}
                       transition={{ duration: 0.24 }}
                     >
-                      <DesignerSelector value={formData.designer} onChange={handleDesignerChange} />
+                      <DesignerSelector designers={designerSource} value={formData.designer} onChange={handleDesignerChange} />
                     </motion.div>
                   )}
                   {step >= 3 && (
@@ -183,9 +202,9 @@ const BookingPage = () => {
                       exit={{ opacity: 0, x: 32 }}
                       transition={{ duration: 0.24 }}
                     >
-                      <ServiceCategorySelector value={formData.category} onChange={() => { }} />
-                      <ServiceSelector value={formData.service} category={formData.category} onChange={() => { }} />
-                      <DesignerSelector value={formData.designer} onChange={() => { }} />
+                      <ServiceCategorySelector categories={categorySource} value={formData.category} onChange={() => { }} />
+                      <ServiceSelector categories={categorySource} value={formData.service} category={formData.category} onChange={() => { }} />
+                      <DesignerSelector designers={designerSource} value={formData.designer} onChange={() => { }} />
                       <SidebarMask text="Your selections are locked in. To change, go back." />
                     </motion.div>
                   )}

--- a/src/pages/TeamPage/TeamPage.tsx
+++ b/src/pages/TeamPage/TeamPage.tsx
@@ -1,9 +1,21 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import TeammateCard from "../../components/TeammateCard/TeammateCard";
 import "./TeamPage.css";
-import { designers } from "../../data/designers";
+import { designers as fallbackDesigners, type Designer } from "../../data/designers";
 
-const TeamPage = () => (
+const TeamPage = () => {
+  const [team, setTeam] = useState<Designer[]>([]);
+
+  useEffect(() => {
+    fetch('/api/designers')
+      .then(res => res.json())
+      .then(setTeam)
+      .catch(() => setTeam([]));
+  }, []);
+
+  const data = team.length ? team : fallbackDesigners;
+
+  return (
   <div className="team-bg">
     <main className="team-main">
       {/* Page Header */}
@@ -16,7 +28,7 @@ const TeamPage = () => (
       </header>
 
       <section className="team-grid">
-        {designers.map((designer) => (
+        {data.map((designer) => (
           <TeammateCard
             key={designer.name}
             name={designer.name}
@@ -28,6 +40,7 @@ const TeamPage = () => (
       </section>
     </main>
   </div>
-);
+  );
+};
 
 export default TeamPage;


### PR DESCRIPTION
## Summary
- connect front-end pages to backend APIs
- add endpoint to list service categories
- support loading categories, services, and designers from the server
- stub fetch in Jest setup so tests pass
- add customer review and gallery image tables with routes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_683fd23f69148330a7eda876209301bf