### PR TITLE
Add dark theme toggle

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,6 +2,7 @@ import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.tsx'
 import { AuthProvider } from './contexts/AuthContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 jest.mock('swiper/react', () => ({
   Swiper: ({ children }: any) => <div>{children}</div>,
@@ -26,9 +27,11 @@ jest.mock('./containers/footer/Footer', () => () => <div>Footer</div>);
 
 test('renders header', () => {
   render(
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   )
   expect(screen.getByText(/REAMY NAIL & BEAUTY/i)).toBeInTheDocument()
 })

--- a/src/__tests__/components/Header.test.tsx
+++ b/src/__tests__/components/Header.test.tsx
@@ -2,15 +2,18 @@ import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import Header from '@/components/Header/Header'
 import { AuthProvider } from '@/contexts/AuthContext'
+import { ThemeProvider } from '@/contexts/ThemeContext'
 import '@testing-library/jest-dom'
 
 test('renders header logo text', () => {
   render(
-    <AuthProvider>
-      <BrowserRouter>
-        <Header />
-      </BrowserRouter>
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <BrowserRouter>
+          <Header />
+        </BrowserRouter>
+      </AuthProvider>
+    </ThemeProvider>
   )
   expect(screen.getByText(/REAMY NAIL & BEAUTY/i)).toBeInTheDocument()
 })

--- a/src/components/BlogCard/BlogCard.css
+++ b/src/components/BlogCard/BlogCard.css
@@ -1,5 +1,5 @@
 .blog-card {
-  background-color: white;
+  background-color: var(--color-card-bg);
   border-radius: 0.5rem;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
   overflow: hidden;

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -6,7 +6,7 @@ html {
   position: sticky;
   top: 0;
   z-index: 50;
-  background-color: white;
+  background-color: hsl(var(--background));
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
 }
 
@@ -68,7 +68,7 @@ html {
   left: 0;
   margin-top: 0.5rem;
   width: 12rem;
-  background: white;
+  background: hsl(var(--card));
   border-radius: 0.375rem;
   box-shadow: 0 5px 15px rgba(0, 0, 0, 0.1);
   z-index: 20;
@@ -127,8 +127,16 @@ html {
   cursor: pointer;
 }
 
-.book-button:hover {
-  background-color: var(--color-primary-hover);
+  .book-button:hover {
+    background-color: var(--color-primary-hover);
+  }
+
+.theme-toggle {
+  color: var(--color-text-dark);
+}
+
+.theme-toggle:hover {
+  color: var(--color-primary);
 }
 
 /* Mobile styles */
@@ -138,7 +146,7 @@ html {
 }
 
 .mobile-nav {
-  background: white;
+  background: hsl(var(--card));
   box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
   padding: 1rem;
 }

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -1,11 +1,12 @@
 import { useState, useRef, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { Menu, X, ChevronDown, LogIn, UserPlus, LogOut } from "lucide-react";
+import { Menu, X, ChevronDown, LogIn, UserPlus, LogOut, Sun, Moon } from "lucide-react";
 import { Button } from "../ui/button";
 import { useAuth } from "@/contexts/AuthContext";
 import { cn } from "@/lib/utils";
 import "./Header.css";
 import { headerContent } from "@/data/content";
+import { useTheme } from "@/contexts/ThemeContext";
 import logo192 from '@/assets/icons/logo192.png';
 import { motion, AnimatePresence } from "framer-motion";
 
@@ -14,6 +15,7 @@ const Header = () => {
   const [activeDropdown, setActiveDropdown] = useState<string | null>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
   const { user, logout } = useAuth();
+  const { theme, toggleTheme } = useTheme();
 
   useEffect(() => {
     const handleClickOutside = (e: MouseEvent) =>
@@ -81,6 +83,15 @@ const Header = () => {
               </Link>
             </>
           )}
+          <Button
+            variant="ghost"
+            size="icon"
+            className="theme-toggle"
+            onClick={toggleTheme}
+            aria-label="Toggle theme"
+          >
+            {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+          </Button>
           <div className="book-button-desktop">
             <Link to="/booking"><Button className="book-button">{headerContent.bookNowButton}</Button></Link>
           </div>
@@ -143,6 +154,15 @@ const Header = () => {
             )}
             <div className="mobile-book-button">
               <Link to="/booking"><Button className="book-button">{headerContent.bookNowButton}</Button></Link>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="theme-toggle ml-2"
+                onClick={() => { toggleTheme(); }}
+                aria-label="Toggle theme"
+              >
+                {theme === 'dark' ? <Sun size={20} /> : <Moon size={20} />}
+              </Button>
             </div>
           </motion.div>
         )}

--- a/src/components/OurServiceCard/OurServiceCard.css
+++ b/src/components/OurServiceCard/OurServiceCard.css
@@ -1,5 +1,5 @@
 .our-card {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 10px;
   overflow: hidden;
   box-shadow: 0 2px 10px 0 rgba(32,48,60,.08);

--- a/src/components/ServiceCard/ServiceCard.css
+++ b/src/components/ServiceCard/ServiceCard.css
@@ -4,7 +4,7 @@
   overflow: hidden;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
   transition: transform 0.3s ease;
-  background-color: #fff;
+  background-color: var(--color-card-bg);
 }
 
 .service-card:hover {

--- a/src/components/TeammateCard/TeammateCard.css
+++ b/src/components/TeammateCard/TeammateCard.css
@@ -1,5 +1,5 @@
 .teammate-card {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 20px;
   box-shadow: 0 6px 24px rgba(32,48,60,0.09);
   display: flex;

--- a/src/components/TestimonialCard/TestimonialCard.css
+++ b/src/components/TestimonialCard/TestimonialCard.css
@@ -1,6 +1,6 @@
 /* TestimonialCard.css */
 .testimonial-card {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 12px;
   padding: 2rem;
   box-shadow: 0 2px 12px rgba(0, 0, 0, 0.08);

--- a/src/containers/gallery/Gallery.css
+++ b/src/containers/gallery/Gallery.css
@@ -1,6 +1,6 @@
 .gallery-section {
   padding: 4rem 0;
-  background-color: #fff1e6;
+  background-color: hsl(var(--background));
 }
 
 .gallery-container {

--- a/src/containers/gift-cards/GiftCards.css
+++ b/src/containers/gift-cards/GiftCards.css
@@ -83,7 +83,7 @@
 }
 
 .promo-button {
-  background-color: white;
+  background-color: var(--color-card-bg);
   color: var(--color-primary);
   cursor: pointer;
 }

--- a/src/containers/hero/Hero.css
+++ b/src/containers/hero/Hero.css
@@ -97,7 +97,7 @@
 }
 
 .hero-dot.active {
-  background-color: white;
+  background-color: var(--color-card-bg);
   transform: scale(1.25);
 }
 

--- a/src/containers/latest-news/LatestNews.css
+++ b/src/containers/latest-news/LatestNews.css
@@ -68,7 +68,7 @@
 
 /* BlogCard styles */
 .blog-card {
-  background-color: white;
+  background-color: var(--color-card-bg);
   border-radius: 0.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
   overflow: hidden;

--- a/src/containers/nail-care/NailCare.css
+++ b/src/containers/nail-care/NailCare.css
@@ -46,7 +46,7 @@
 }
 
 .nailcare-button {
-  background-color: white;
+  background-color: var(--color-card-bg);
   color: var(--color-primary);
 }
 

--- a/src/containers/pricing/Pricing.css
+++ b/src/containers/pricing/Pricing.css
@@ -2,7 +2,7 @@
 /* SECTION */
 .pricing-section {
   padding: 4rem 0;
-  background-color: white;
+  background-color: var(--color-card-bg);
 }
 
 .pricing-container {
@@ -52,7 +52,7 @@
 
 /* CARD */
 .price-card {
-  background: white;
+  background: var(--color-card-bg);
   border-radius: 0.5rem;
   overflow: hidden;
   box-shadow: 0 6px 16px rgba(0, 0, 0, 0.05);

--- a/src/containers/services/Services.css
+++ b/src/containers/services/Services.css
@@ -1,6 +1,6 @@
 .services-section {
   padding: 4rem 0;
-  background-color: #fff1e6;
+  background-color: hsl(var(--background));
 }
 
 .services-container {

--- a/src/containers/skilled-nail-art/SkilledNailArt.css
+++ b/src/containers/skilled-nail-art/SkilledNailArt.css
@@ -1,6 +1,6 @@
 .skilled-section {
   padding: 5rem 0;
-  background-color: white;
+  background-color: var(--color-card-bg);
 }
 
 .skilled-container {

--- a/src/containers/testimonials/Testimonials.css
+++ b/src/containers/testimonials/Testimonials.css
@@ -44,7 +44,7 @@
 }
 
 .testimonial-card {
-  background-color: white;
+  background-color: var(--color-card-bg);
   padding: 2rem;
   border-radius: 0.5rem;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.05);
@@ -97,7 +97,7 @@ blockquote {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
-  background-color: white;
+  background-color: var(--color-card-bg);
   padding: 0.5rem;
   border-radius: 9999px;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);

--- a/src/contexts/ThemeContext.tsx
+++ b/src/contexts/ThemeContext.tsx
@@ -1,0 +1,38 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps | undefined>(undefined);
+
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme');
+    if (stored === 'dark') setTheme('dark');
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme(t => (t === 'dark' ? 'light' : 'dark'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error('useTheme must be used within ThemeProvider');
+  return ctx;
+};

--- a/src/globals.css
+++ b/src/globals.css
@@ -28,6 +28,7 @@
     --color-text-dark: #2c3e50;
     --color-text-muted: #6c757d;
     --color-bg-light: #f9fafb;
+    --color-card-bg: #ffffff;
     --radius: 0.5rem;
   }
 
@@ -51,6 +52,10 @@
     --destructive: 0 63% 31%;
     --destructive-foreground: 210 40% 98%;
     --ring: 216 34% 17%;
+    --color-text-dark: #f3f4f6;
+    --color-text-muted: #9ca3af;
+    --color-bg-light: #1f2937;
+    --color-card-bg: #1e293b;
   }
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,14 @@ import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './globals.css'
 import { AuthProvider } from './contexts/AuthContext'
+import { ThemeProvider } from './contexts/ThemeContext'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <AuthProvider>
-      <App />
-    </AuthProvider>
+    <ThemeProvider>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </ThemeProvider>
   </React.StrictMode>,
 )

--- a/src/pages/Auth/LoginPage/LoginPage.css
+++ b/src/pages/Auth/LoginPage/LoginPage.css
@@ -1,6 +1,6 @@
 .login-bg {
   min-height: 100vh;
-  background: #fff1e6;
+  background: hsl(var(--background));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8,7 +8,7 @@
 }
 
 .login-form {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 18px;
   box-shadow: 0 8px 32px rgba(32, 48, 60, 0.13);
   width: 100%;

--- a/src/pages/BookingPage/BookingPage.css
+++ b/src/pages/BookingPage/BookingPage.css
@@ -5,7 +5,7 @@
   padding: 2rem;
   border-radius: 12px;
   box-shadow: 0 0 20px rgba(0, 0, 0, 0.4);
-  background: #fff;
+  background: var(--color-card-bg);
 }
 
 .booking-header {
@@ -126,7 +126,7 @@
 }
 
 .modal-content {
-  background: #fff;
+  background: var(--color-card-bg);
   padding: 2rem 2.5rem;
   border-radius: 14px;
   min-width: 340px;

--- a/src/pages/ContactUsPage/ContactUsPage.css
+++ b/src/pages/ContactUsPage/ContactUsPage.css
@@ -1,6 +1,6 @@
 .contact-bg {
   min-height: 100vh;
-  background: #fff1e6;
+  background: hsl(var(--background));
   color: #fff;
   font-family: 'Inter', Arial, sans-serif;
   display: flex;

--- a/src/pages/GiftCardPage/GiftCardPage.css
+++ b/src/pages/GiftCardPage/GiftCardPage.css
@@ -1,6 +1,6 @@
 .giftcard-demo-bg {
   min-height: 100vh;
-  background: #fff1e6;
+  background: hsl(var(--background));
   display: flex;
   align-items: center;
   justify-content: center;
@@ -8,7 +8,7 @@
 }
 
 .giftcard-demo-container {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 18px;
   box-shadow: 0 8px 32px rgba(32, 48, 60, 0.13);
   max-width: 420px;
@@ -48,7 +48,7 @@
 
 .giftcard-amount-btn {
   border: 1.5px solid var(--color-primary);
-  background: #fff;
+  background: var(--color-card-bg);
   color: var(--color-primary);
   font-size: 1rem;
   font-weight: 600;

--- a/src/pages/ServicesPage/ServicesPage.css
+++ b/src/pages/ServicesPage/ServicesPage.css
@@ -1,6 +1,6 @@
 .services-bg {
   min-height: 100vh;
-  background: #fff1e6;
+  background: hsl(var(--background));
   padding-top: 4rem;
   padding-bottom: 4rem;
 }
@@ -131,7 +131,7 @@
 
 /* Booking Info */
 .services-booking-info {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 18px;
   box-shadow: 0 4px 18px rgba(32,48,60,0.05);
   max-width: 700px;

--- a/src/pages/TeamPage/TeamPage.css
+++ b/src/pages/TeamPage/TeamPage.css
@@ -1,6 +1,6 @@
 .team-bg {
   min-height: 100vh;
-  background: #fff1e6;
+  background: hsl(var(--background));
   padding-top: 2.5rem;
   padding-bottom: 2.5rem;
 }
@@ -13,7 +13,7 @@
 }
 
 .team-hero {
-  background: #fff;
+  background: var(--color-card-bg);
   border-radius: 18px;
   box-shadow: 0 4px 18px rgba(32,48,60,0.08);
   padding: 2rem 1rem;


### PR DESCRIPTION
## Summary
- implement ThemeContext for dark/light switching
- add toggle button with icons in `Header`
- update global CSS variables for dark theme
- update many component styles to use theme variables
- adjust tests to include ThemeProvider

## Testing
- `npm test`
- `npm run typecheck` *(fails: Module '@/data/content' has no exported member)*

------
https://chatgpt.com/codex/tasks/task_e_6840d95721ac8330a96471efaf5b5f31