### PR TITLE
Add sample bookings and slot linking

### DIFF
--- a/server/models/bookingModel.js
+++ b/server/models/bookingModel.js
@@ -1,12 +1,25 @@
 import { prisma } from '../prisma/client.js';
 
 export function getBookingsForUser(userId) {
-  return prisma.booking.findMany({
+  return prisma.bookings.findMany({
     where: { userId },
     include: { service: true, designer: true }
   });
 }
 
 export function createBooking(data) {
-  return prisma.booking.create({ data });
+  return prisma.bookings.create({ data });
+}
+
+export function findAvailable(designerId, startTime, endTime) {
+  return prisma.availableAppointments.findFirst({
+    where: { designerId, startTime, endTime, booked: false }
+  });
+}
+
+export function bookSlot(id) {
+  return prisma.availableAppointments.update({
+    where: { id },
+    data: { booked: true }
+  });
 }

--- a/server/models/designerModel.js
+++ b/server/models/designerModel.js
@@ -3,3 +3,21 @@ import { prisma } from '../prisma/client.js';
 export function getAllDesigners() {
   return prisma.designers.findMany();
 }
+
+export function getServicesForDesigner(designerId) {
+  return prisma.designerServices.findMany({
+    where: { designerId },
+    include: { Services: true }
+  });
+}
+
+export function getAvailableAppointmentsForDesigner(designerId) {
+  return prisma.availableAppointments.findMany({
+    where: { designerId, booked: false }
+  });
+}
+
+export async function designerCanPerformService(designerId, serviceId) {
+  const count = await prisma.designerServices.count({ where: { designerId, serviceId } });
+  return count > 0;
+}

--- a/server/models/designerModel.js
+++ b/server/models/designerModel.js
@@ -1,23 +1,35 @@
 import { prisma } from '../prisma/client.js';
 
+export async function resolveDesignerId(idOrName) {
+  if (typeof idOrName === 'number') return idOrName;
+  const designer = await prisma.designers.findFirst({ where: { name: idOrName } });
+  return designer ? designer.id : null;
+}
+
 export function getAllDesigners() {
   return prisma.designers.findMany();
 }
 
-export function getServicesForDesigner(designerId) {
+export async function getServicesForDesigner(idOrName) {
+  const designerId = await resolveDesignerId(idOrName);
+  if (!designerId) return null;
   return prisma.designerServices.findMany({
     where: { designerId },
     include: { Services: true }
   });
 }
 
-export function getAvailableAppointmentsForDesigner(designerId) {
+export async function getAvailableAppointmentsForDesigner(idOrName) {
+  const designerId = await resolveDesignerId(idOrName);
+  if (!designerId) return null;
   return prisma.availableAppointments.findMany({
     where: { designerId, booked: false }
   });
 }
 
 export async function designerCanPerformService(designerId, serviceId) {
-  const count = await prisma.designerServices.count({ where: { designerId, serviceId } });
+  const id = await resolveDesignerId(designerId);
+  if (!id) return false;
+  const count = await prisma.designerServices.count({ where: { designerId: id, serviceId } });
   return count > 0;
 }

--- a/server/mssql/schema.sql
+++ b/server/mssql/schema.sql
@@ -83,7 +83,8 @@ CREATE TABLE Bookings (
   CONSTRAINT FK_Booking_User FOREIGN KEY (userId) REFERENCES Users(id),
   CONSTRAINT FK_Booking_Designer FOREIGN KEY (designerId) REFERENCES Designers(id),
   CONSTRAINT FK_Booking_Service FOREIGN KEY (serviceId) REFERENCES Services(id),
-  CONSTRAINT FK_Booking_Available FOREIGN KEY (slotId) REFERENCES AvailableAppointments(id)
+  CONSTRAINT FK_Booking_Available FOREIGN KEY (slotId) REFERENCES AvailableAppointments(id),
+  CONSTRAINT UQ_Booking_Slot UNIQUE (slotId)
 );
 GO
 

--- a/server/mssql/schema.sql
+++ b/server/mssql/schema.sql
@@ -51,17 +51,39 @@ CREATE TABLE Services (
 );
 GO
 
+CREATE TABLE DesignerServices (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  designerId INT NOT NULL,
+  serviceId INT NOT NULL,
+  CONSTRAINT FK_DS_Designer FOREIGN KEY (designerId) REFERENCES Designers(id),
+  CONSTRAINT FK_DS_Service FOREIGN KEY (serviceId) REFERENCES Services(id),
+  CONSTRAINT UQ_Designer_Service UNIQUE (designerId, serviceId)
+);
+GO
+
+CREATE TABLE AvailableAppointments (
+  id INT IDENTITY(1,1) PRIMARY KEY,
+  designerId INT NOT NULL,
+  startTime DATETIME2 NOT NULL,
+  endTime DATETIME2 NOT NULL,
+  booked BIT NOT NULL DEFAULT 0,
+  CONSTRAINT FK_Available_Designer FOREIGN KEY (designerId) REFERENCES Designers(id)
+);
+GO
+
 CREATE TABLE Bookings (
   id INT IDENTITY(1,1) PRIMARY KEY,
   userId INT NOT NULL,
   designerId INT NOT NULL,
   serviceId INT NOT NULL,
+  slotId INT NOT NULL,
   startTime DATETIME2 NOT NULL,
   endTime DATETIME2 NOT NULL,
   createdAt DATETIME2 NOT NULL DEFAULT SYSDATETIME(),
   CONSTRAINT FK_Booking_User FOREIGN KEY (userId) REFERENCES Users(id),
   CONSTRAINT FK_Booking_Designer FOREIGN KEY (designerId) REFERENCES Designers(id),
-  CONSTRAINT FK_Booking_Service FOREIGN KEY (serviceId) REFERENCES Services(id)
+  CONSTRAINT FK_Booking_Service FOREIGN KEY (serviceId) REFERENCES Services(id),
+  CONSTRAINT FK_Booking_Available FOREIGN KEY (slotId) REFERENCES AvailableAppointments(id)
 );
 GO
 
@@ -226,3 +248,44 @@ INSERT INTO GalleryImages (id, url, caption) VALUES
   (24, '/assets/nail-gallery/24.webp', NULL);
 SET IDENTITY_INSERT GalleryImages OFF;
 GO
+
+-- Seed data for DesignerServices
+INSERT INTO DesignerServices (designerId, serviceId) VALUES
+  (1, 1),
+  (1, 2),
+  (2, 5),
+  (3, 8);
+GO
+
+-- Seed data for AvailableAppointments
+SET IDENTITY_INSERT AvailableAppointments ON;
+INSERT INTO AvailableAppointments (id, designerId, startTime, endTime, booked) VALUES
+  (1, 1, '2024-01-01T10:00:00', '2024-01-01T10:30:00', 0),
+  (2, 1, '2024-01-01T11:00:00', '2024-01-01T11:30:00', 0),
+  (3, 2, '2024-01-02T13:00:00', '2024-01-02T13:30:00', 0),
+  (4, 3, '2024-01-03T09:00:00', '2024-01-03T09:30:00', 0),
+  (5, 1, '2024-05-31T10:00:00', '2024-05-31T10:30:00', 1),
+  (6, 2, '2024-06-05T14:00:00', '2024-06-05T14:30:00', 1),
+  (7, 3, '2024-06-20T09:00:00', '2024-06-20T09:30:00', 0),
+  (8, 1, '2024-07-01T10:00:00', '2024-07-01T10:30:00', 0),
+  (9, 2, '2024-07-15T13:00:00', '2024-07-15T13:30:00', 0),
+  (10, 3, '2024-07-22T09:00:00', '2024-07-22T09:30:00', 0),
+  (11, 1, '2024-08-05T10:00:00', '2024-08-05T10:30:00', 0),
+  (12, 2, '2024-08-12T13:00:00', '2024-08-12T13:30:00', 0),
+  (13, 3, '2024-08-26T09:00:00', '2024-08-26T09:30:00', 0);
+SET IDENTITY_INSERT AvailableAppointments OFF;
+GO
+
+-- Seed demo user for bookings
+SET IDENTITY_INSERT Users ON;
+INSERT INTO Users (id, username, email, phone, firstName, lastName, language, password)
+VALUES (1, 'demo', 'demo@example.com', '555-0100', 'Demo', 'User', 'en', 'password');
+SET IDENTITY_INSERT Users OFF;
+
+-- Seed data for Bookings over the past two weeks
+SET IDENTITY_INSERT Bookings ON;
+INSERT INTO Bookings (id, userId, designerId, serviceId, slotId, startTime, endTime, createdAt)
+VALUES
+  (1, 1, 1, 1, 5, '2024-05-31T10:00:00', '2024-05-31T10:30:00', SYSDATETIME()),
+  (2, 1, 2, 5, 6, '2024-06-05T14:00:00', '2024-06-05T14:30:00', SYSDATETIME());
+SET IDENTITY_INSERT Bookings OFF;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,11 +12,13 @@ model Bookings {
   userId       Int
   designerId   Int
   serviceId    Int
+  slotId       Int
   startTime    DateTime
   endTime      DateTime
   createdAt    DateTime       @default(dbgenerated("sysdatetime()"), map: "DF__Bookings__create__440B1D61")
   Designers    Designers      @relation(fields: [designerId], references: [id], onUpdate: NoAction, map: "FK_Booking_Designer")
   Services     Services       @relation(fields: [serviceId], references: [id], onUpdate: NoAction, map: "FK_Booking_Service")
+  AvailableAppointments AvailableAppointments @relation(fields: [slotId], references: [id], onUpdate: NoAction, map: "FK_Booking_Available")
   Users        Users          @relation(fields: [userId], references: [id], onUpdate: NoAction, map: "FK_Booking_User")
   Transactions Transactions[]
 }
@@ -37,6 +39,8 @@ model Designers {
   avatar   String     @db.NVarChar(255)
   bio      String     @db.NVarChar(255)
   Bookings Bookings[]
+  DesignerServices DesignerServices[]
+  AvailableAppointments AvailableAppointments[]
 }
 
 model GalleryImages {
@@ -67,6 +71,7 @@ model Services {
   image             String?           @db.NVarChar(255)
   categoryId        Int
   Bookings          Bookings[]
+  DesignerServices  DesignerServices[]
   ServiceCategories ServiceCategories @relation(fields: [categoryId], references: [id], onUpdate: NoAction, map: "FK_Service_Category")
 }
 
@@ -94,4 +99,23 @@ model Users {
   createdAt    DateTime       @default(dbgenerated("sysdatetime()"), map: "DF__Users__createdAt__398D8EEE")
   Bookings     Bookings[]
   Transactions Transactions[]
+}
+
+model DesignerServices {
+  id         Int       @id @default(autoincrement())
+  designerId Int
+  serviceId  Int
+  Designers  Designers @relation(fields: [designerId], references: [id], onUpdate: NoAction, map: "FK_DS_Designer")
+  Services   Services  @relation(fields: [serviceId], references: [id], onUpdate: NoAction, map: "FK_DS_Service")
+  @@unique([designerId, serviceId], map: "UQ_Designer_Service")
+}
+
+model AvailableAppointments {
+  id         Int       @id @default(autoincrement())
+  designerId Int
+  startTime  DateTime
+  endTime    DateTime
+  booked     Boolean   @default(false)
+  Designers  Designers @relation(fields: [designerId], references: [id], onUpdate: NoAction, map: "FK_Available_Designer")
+  Bookings   Bookings?
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -117,5 +117,5 @@ model AvailableAppointments {
   endTime    DateTime
   booked     Boolean   @default(false)
   Designers  Designers @relation(fields: [designerId], references: [id], onUpdate: NoAction, map: "FK_Available_Designer")
-  Bookings   Bookings? @relation(fields: [id], references: [slotId])
+  Bookings   Bookings?
 }

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -12,7 +12,7 @@ model Bookings {
   userId       Int
   designerId   Int
   serviceId    Int
-  slotId       Int
+  slotId       Int      @unique
   startTime    DateTime
   endTime      DateTime
   createdAt    DateTime       @default(dbgenerated("sysdatetime()"), map: "DF__Bookings__create__440B1D61")
@@ -117,5 +117,5 @@ model AvailableAppointments {
   endTime    DateTime
   booked     Boolean   @default(false)
   Designers  Designers @relation(fields: [designerId], references: [id], onUpdate: NoAction, map: "FK_Available_Designer")
-  Bookings   Bookings?
+  Bookings   Bookings? @relation(fields: [id], references: [slotId])
 }

--- a/server/routes/bookingRoutes.js
+++ b/server/routes/bookingRoutes.js
@@ -11,13 +11,17 @@ router.get('/', async (req, res) => {
 });
 
 router.post('/', async (req, res) => {
-  const booking = await addBooking({
-    ...req.body,
-    userId: req.userId,
-    startTime: new Date(req.body.startTime),
-    endTime: new Date(req.body.endTime)
-  });
-  res.json(booking);
+  try {
+    const booking = await addBooking({
+      ...req.body,
+      userId: req.userId,
+      startTime: new Date(req.body.startTime),
+      endTime: new Date(req.body.endTime)
+    });
+    res.json(booking);
+  } catch (e) {
+    res.status(400).json({ error: e.message });
+  }
 });
 
 export default router;

--- a/server/routes/designerRoutes.js
+++ b/server/routes/designerRoutes.js
@@ -9,20 +9,18 @@ router.get('/', async (_req, res) => {
 });
 
 router.get('/:id/services', async (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  if (Number.isNaN(id)) {
-    return res.status(400).json({ error: 'Invalid designer ID' });
+  const services = await listDesignerServices(req.params.id);
+  if (!services) {
+    return res.status(404).json({ error: 'Designer not found' });
   }
-  const services = await listDesignerServices(id);
   res.json(services.map(s => s.Services));
 });
 
 router.get('/:id/slots', async (req, res) => {
-  const id = parseInt(req.params.id, 10);
-  if (Number.isNaN(id)) {
-    return res.status(400).json({ error: 'Invalid designer ID' });
+  const slots = await listDesignerSlots(req.params.id);
+  if (!slots) {
+    return res.status(404).json({ error: 'Designer not found' });
   }
-  const slots = await listDesignerSlots(id);
   res.json(slots);
 });
 

--- a/server/routes/designerRoutes.js
+++ b/server/routes/designerRoutes.js
@@ -1,11 +1,23 @@
 import express from 'express';
-import { listDesigners } from '../services/designerService.js';
+import { listDesigners, listDesignerServices, listDesignerSlots } from '../services/designerService.js';
 
 const router = express.Router();
 
 router.get('/', async (_req, res) => {
   const designers = await listDesigners();
   res.json(designers);
+});
+
+router.get('/:id/services', async (req, res) => {
+  const id = parseInt(req.params.id);
+  const services = await listDesignerServices(id);
+  res.json(services.map(s => s.Services));
+});
+
+router.get('/:id/slots', async (req, res) => {
+  const id = parseInt(req.params.id);
+  const slots = await listDesignerSlots(id);
+  res.json(slots);
 });
 
 export default router;

--- a/server/routes/designerRoutes.js
+++ b/server/routes/designerRoutes.js
@@ -9,13 +9,19 @@ router.get('/', async (_req, res) => {
 });
 
 router.get('/:id/services', async (req, res) => {
-  const id = parseInt(req.params.id);
+  const id = parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid designer ID' });
+  }
   const services = await listDesignerServices(id);
   res.json(services.map(s => s.Services));
 });
 
 router.get('/:id/slots', async (req, res) => {
-  const id = parseInt(req.params.id);
+  const id = parseInt(req.params.id, 10);
+  if (Number.isNaN(id)) {
+    return res.status(400).json({ error: 'Invalid designer ID' });
+  }
   const slots = await listDesignerSlots(id);
   res.json(slots);
 });

--- a/server/services/bookingService.js
+++ b/server/services/bookingService.js
@@ -1,9 +1,19 @@
-import { createBooking, getBookingsForUser } from '../models/bookingModel.js';
+import { createBooking, getBookingsForUser, findAvailable, bookSlot } from '../models/bookingModel.js';
+import { designerCanPerformService } from '../models/designerModel.js';
 
 export function listBookings(userId) {
   return getBookingsForUser(userId);
 }
 
-export function addBooking(data) {
-  return createBooking(data);
+export async function addBooking(data) {
+  const allowed = await designerCanPerformService(data.designerId, data.serviceId);
+  if (!allowed) throw new Error('DESIGNER_SERVICE_MISMATCH');
+  const slot = await findAvailable(data.designerId, data.startTime, data.endTime);
+  if (!slot) throw new Error('SLOT_UNAVAILABLE');
+  const booking = await createBooking({
+    ...data,
+    slotId: slot.id
+  });
+  await bookSlot(slot.id);
+  return booking;
 }

--- a/server/services/bookingService.js
+++ b/server/services/bookingService.js
@@ -1,17 +1,20 @@
 import { createBooking, getBookingsForUser, findAvailable, bookSlot } from '../models/bookingModel.js';
-import { designerCanPerformService } from '../models/designerModel.js';
+import { designerCanPerformService, resolveDesignerId } from '../models/designerModel.js';
 
 export function listBookings(userId) {
   return getBookingsForUser(userId);
 }
 
 export async function addBooking(data) {
-  const allowed = await designerCanPerformService(data.designerId, data.serviceId);
+  const designerId = await resolveDesignerId(data.designerId);
+  if (!designerId) throw new Error('DESIGNER_NOT_FOUND');
+  const allowed = await designerCanPerformService(designerId, data.serviceId);
   if (!allowed) throw new Error('DESIGNER_SERVICE_MISMATCH');
-  const slot = await findAvailable(data.designerId, data.startTime, data.endTime);
+  const slot = await findAvailable(designerId, data.startTime, data.endTime);
   if (!slot) throw new Error('SLOT_UNAVAILABLE');
   const booking = await createBooking({
     ...data,
+    designerId,
     slotId: slot.id
   });
   await bookSlot(slot.id);

--- a/server/services/designerService.js
+++ b/server/services/designerService.js
@@ -1,5 +1,13 @@
-import { getAllDesigners } from '../models/designerModel.js';
+import { getAllDesigners, getServicesForDesigner, getAvailableAppointmentsForDesigner } from '../models/designerModel.js';
 
 export function listDesigners() {
   return getAllDesigners();
+}
+
+export function listDesignerServices(id) {
+  return getServicesForDesigner(id);
+}
+
+export function listDesignerSlots(id) {
+  return getAvailableAppointmentsForDesigner(id);
 }

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -8,7 +8,7 @@ import Scheduler from '@/components/Scheduler/Scheduler';
 import StepProgressBar from '@/components/StepProgressBar/StepProgressBar';
 import ReviewModal from '@/components/ReviewModal/ReviewModal';
 import SidebarMask from '@/components/SidebarMask/SidebarMask';
-import { getDummyBookings, BookingEvent } from '@/data/availableSlots';
+import { type BookingEvent } from '@/data/availableSlots';
 import { type CategoryServiceItem } from '@/data/pricing';
 import { type Designer } from '@/data/designers';
 import { motion, AnimatePresence } from "framer-motion";
@@ -29,6 +29,7 @@ const BookingPage = () => {
 
   const [categories, setCategories] = useState<CategoryServiceItem[]>([]);
   const [designerData, setDesignerData] = useState<Designer[]>([]);
+  const [designerServices, setDesignerServices] = useState<any[]>([]);
 
   const [formData, setFormData] = useState({
     category: null as number | null,
@@ -93,10 +94,35 @@ useEffect(() => {
   }, [navState.category, navState.service]);
 
   useEffect(() => {
-    setEvents(getDummyBookings());
-  }, []);
+    if (!formData.designer) return;
+    fetch(`${API_BASE_URL}/designers/${formData.designer}/services`)
+      .then(res => res.json())
+      .then(data => setDesignerServices(data))
+      .catch(() => setDesignerServices([]));
 
-  const categorySource = categories;
+    fetch(`${API_BASE_URL}/designers/${formData.designer}/slots`)
+      .then(res => res.json())
+      .then(data => {
+        setEvents(
+          data.map((s: any) => ({
+            title: '',
+            start: new Date(s.startTime),
+            end: new Date(s.endTime),
+          }))
+        );
+      })
+      .catch(() => setEvents([]));
+  }, [formData.designer]);
+
+
+  const categorySource = formData.designer
+    ? categories.map(cat => ({
+        ...cat,
+        Services: (cat.Services || []).filter(s =>
+          designerServices.some(ds => ds.id === s.id)
+        ),
+      })).filter(cat => cat.Services && cat.Services.length > 0)
+    : categories;
   const designerSource = designerData;
 
   const goToStep = (targetStep: number) => {
@@ -145,18 +171,25 @@ useEffect(() => {
 
   const handleSubmit = (e?: React.FormEvent) => {
     if (e) e.preventDefault();
-    setEvents(prev => [
-      ...prev,
-      {
-        title: `${formData.service} w/ ${formData.designer}`,
-        start: formData.start!,
-        end: formData.end!,
-      },
-    ]);
-    setShowReview(false);
-    alert(`Appointment booked on ${formData.start?.toLocaleString()}`);
-    setStep(0);
-    setFormData({ category: null, service: '', designer: '', start: null, end: null });
+    const serviceObj = categories
+      .flatMap(c => c.Services || [])
+      .find(s => (s.title || s.name) === formData.service);
+    if (!serviceObj) return;
+    fetch(`${API_BASE_URL}/bookings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        serviceId: serviceObj.id,
+        designerId: parseInt(formData.designer),
+        startTime: formData.start,
+        endTime: formData.end,
+      })
+    })
+      .then(() => {
+        setShowReview(false);
+        setStep(0);
+        setFormData({ category: null, service: '', designer: '', start: null, end: null });
+      });
   };
 
   const handleReviewClose = () => {

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -180,7 +180,7 @@ useEffect(() => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         serviceId: serviceObj.id,
-        designerId: parseInt(formData.designer),
+        designerId: formData.designer,
         startTime: formData.start,
         endTime: formData.end,
       })


### PR DESCRIPTION
## Summary
- extend mssql schema with `slotId` and `booked` fields
- seed demo data for users, available appointments, and recent bookings
- connect bookings to available appointments and mark slots booked
- expose only unbooked slots from designer model

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6840e166193c833087a1b634d247a4cc