### PR TITLE
Add booking confirmation page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,6 +18,7 @@ const ContactUsPage = lazy(() => import('./pages/ContactUsPage/ContactUsPage'));
 const GiftCardPage = lazy(() => import('./pages/GiftCardPage/GiftCardPage'));
 const LoginPage = lazy(() => import('./pages/Auth/LoginPage/LoginPage'));
 const RegisterPage = lazy(() => import('./pages/Auth/RegisterPage/RegisterPage'));
+const BookingConfirmationPage = lazy(() => import('./pages/BookingConfirmationPage/BookingConfirmationPage'));
 
 const pageTransition = {
   initial: { opacity: 0, y: 30 },
@@ -59,6 +60,14 @@ function AnimatedRoutes() {
           element={
             <motion.div {...pageTransition}>
               <BookingPage />
+            </motion.div>
+          }
+        />
+        <Route
+          path="/booking-confirmation"
+          element={
+            <motion.div {...pageTransition}>
+              <BookingConfirmationPage />
             </motion.div>
           }
         />

--- a/src/__tests__/pages/pages.test.tsx
+++ b/src/__tests__/pages/pages.test.tsx
@@ -8,6 +8,7 @@ import ContactUsPage from '@/pages/ContactUsPage/ContactUsPage'
 import GiftCardPage from '@/pages/GiftCardPage/GiftCardPage'
 import LoginPage from '@/pages/Auth/LoginPage/LoginPage'
 import RegisterPage from '@/pages/Auth/RegisterPage/RegisterPage'
+import BookingConfirmationPage from '@/pages/BookingConfirmationPage/BookingConfirmationPage'
 
 describe('Page renders', () => {
   it('BookingPage', () => {
@@ -75,5 +76,14 @@ describe('Page renders', () => {
       </AuthProvider>
     )
     expect(screen.getByRole('heading', { name: /register/i })).toBeInTheDocument()
+  })
+
+  it('BookingConfirmationPage', () => {
+    render(
+      <BrowserRouter>
+        <BookingConfirmationPage />
+      </BrowserRouter>
+    )
+    expect(screen.getByRole('heading', { name: /your booking is confirmed/i })).toBeInTheDocument()
   })
 })

--- a/src/pages/BookingConfirmationPage/BookingConfirmationPage.css
+++ b/src/pages/BookingConfirmationPage/BookingConfirmationPage.css
@@ -1,0 +1,25 @@
+.booking-confirmation-page {
+  padding: 3rem 1rem;
+  display: flex;
+  justify-content: center;
+}
+
+.booking-confirmation-container {
+  max-width: 600px;
+  text-align: center;
+}
+
+.confirmation-details {
+  margin: 1rem 0;
+  line-height: 1.6;
+}
+
+.prep-tips ul {
+  list-style: disc;
+  padding-left: 1.5rem;
+  text-align: left;
+}
+
+.back-home-btn {
+  margin-top: 2rem;
+}

--- a/src/pages/BookingConfirmationPage/BookingConfirmationPage.tsx
+++ b/src/pages/BookingConfirmationPage/BookingConfirmationPage.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { useLocation, Link } from 'react-router-dom';
+import './BookingConfirmationPage.css';
+import { Button } from '@/components/ui/button';
+
+interface BookingDetails {
+  category: string;
+  service: string;
+  designer: string;
+  start: Date | string | null;
+  end: Date | string | null;
+}
+
+const BookingConfirmationPage: React.FC = () => {
+  const location = useLocation();
+  const state = (location.state || {}) as BookingDetails;
+
+  const start = state.start ? new Date(state.start) : null;
+  const end = state.end ? new Date(state.end) : null;
+
+  return (
+    <main className="booking-confirmation-page">
+      <div className="booking-confirmation-container">
+        <h2>Your Booking is Confirmed!</h2>
+        <p className="confirmation-details">
+          <strong>Category:</strong> {state.category} <br />
+          <strong>Service:</strong> {state.service} <br />
+          <strong>Artist:</strong> {state.designer} <br />
+          <strong>Date &amp; Time:</strong>{' '}
+          {start?.toLocaleString()} – {end?.toLocaleTimeString()}
+        </p>
+
+        <section className="prep-tips">
+          <h3>Preparation Tips</h3>
+          <ul>
+            <li>Arrive 10 minutes early to settle in.</li>
+            <li>Remove any old polish before your appointment.</li>
+            <li>Inform us of any allergies or sensitivities.</li>
+            <li>Bring open-toed shoes for pedicure services.</li>
+          </ul>
+        </section>
+
+        <Button asChild className="back-home-btn">
+          <Link to="/">Return Home</Link>
+        </Button>
+      </div>
+    </main>
+  );
+};
+
+export default BookingConfirmationPage;

--- a/src/pages/BookingPage/BookingPage.tsx
+++ b/src/pages/BookingPage/BookingPage.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import './BookingPage.css';
 import ServiceCategorySelector from '@/components/ServiceCategorySelector/ServiceCategorySelector';
 import ServiceSelector from '@/components/ServiceSelector/ServiceSelector';
@@ -22,6 +22,7 @@ const steps = [
 
 const BookingPage = () => {
   const location = useLocation();
+  const navigate = useNavigate();
   const navState = location.state || {};
 
   const [formData, setFormData] = useState({
@@ -111,7 +112,7 @@ const BookingPage = () => {
       },
     ]);
     setShowReview(false);
-    alert(`Appointment booked on ${formData.start?.toLocaleString()}`);
+    navigate('/booking-confirmation', { state: formData });
     setStep(0);
     setFormData({ category: '', service: '', designer: '', start: null, end: null });
   };


### PR DESCRIPTION
## Summary
- add BookingConfirmationPage to show final booking details and preparation tips
- redirect to confirmation page after booking
- wire up BookingConfirmationPage route
- update tests for BookingConfirmationPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684476b29b2c833093ac804b841c4516